### PR TITLE
Put correct filename of the example job

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ nomad agent -config=examples/nomad/server.hcl 2>&1 > server.log &
 sudo nomad agent -config=examples/nomad/client.hcl 2>&1 > client.log &
 
 # Run a job
-nomad job run examples/redis.nomad
+nomad job run examples/redis_ports.nomad
 
 # Verify
 nomad job status redis


### PR DESCRIPTION
In commit 2f330430bd2cf65f06755f305f4e78ce6197ee65 file was renamed from redis.nomad to redis_deprecated.nomad and a new file was created with name redis_ports.nomad, but the README.md was not updated.